### PR TITLE
Reorder fw conditions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,9 +111,9 @@
     immediate: true
   become: true
   when:
-    - '"firewalld" in packages'
-    - wtd_srv_ssh_conf.Port is defined
     - wtd_srv_ssh_fw_mgmt|bool
+    - ( "firewalld" in packages and
+      wtd_srv_ssh_conf.Port is defined )
   tags:
     - ssh
     - sshd


### PR DESCRIPTION
I change the order of the condition and also group the package and port part in one condition.
So if `wtd_srv_ssh_fw_mgmt` is `false` the rest of the condition is obsolete.

I faced the issue while using the role for a Debian machine. So it can be possible that `wtd_srv_ssh_fw_mgmt = false` works fine for RedHat/Centos and Fedora. But a better logic will help everyone :)

Feel free to review.

Fix: #7 